### PR TITLE
Copy the JavaDoc to the docs/ folder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ tasks {
         into("docs/javadoc")
     }
 
-    named("assemble") {
+    assemble {
         dependsOn("javadocToDocsFolder")
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,15 @@ tasks {
         maxParallelForks = 1
     }
 
+    create<Copy>("javadocToDocsFolder") {
+        from(javadoc)
+        into("docs/javadoc")
+    }
+
+    named("assemble") {
+        dependsOn("javadocToDocsFolder")
+    }
+
     create<Jar>("sourcesJar") {
         from(sourceSets.main.get().allJava)
         archiveClassifier.set("sources")


### PR DESCRIPTION
The `assemble` task depends on `javadocToDocsFolder` so building triggers the copy.